### PR TITLE
MouseHandler hack

### DIFF
--- a/framework/src/main/java/org/fulib/fx/util/ReflectionUtil.java
+++ b/framework/src/main/java/org/fulib/fx/util/ReflectionUtil.java
@@ -3,22 +3,38 @@ package org.fulib.fx.util;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.stage.Stage;
+import org.fulib.fx.FulibFxApp;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.inject.Provider;
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
-import java.lang.reflect.ParameterizedType;
-import java.lang.reflect.Type;
+import java.lang.reflect.*;
 
 /**
  * Utility class containing different helper methods for the framework or the user.
+ * Parts of this class are hacky and should be used with caution.
  */
 public class ReflectionUtil {
 
     private ReflectionUtil() {
         // Prevent instantiation
+    }
+
+    // Reflection for mouse handler
+    private static Field mouseHandlerField;
+    private static Constructor<?> mouseHandlerCtor;
+
+    static {
+        try {
+            mouseHandlerField = Scene.class.getDeclaredField("mouseHandler");
+            mouseHandlerCtor = Class.forName(Scene.class.getName() + "$MouseHandler").getDeclaredConstructor(Scene.class);
+            mouseHandlerField.setAccessible(true);
+            mouseHandlerCtor.setAccessible(true);
+        } catch (ReflectiveOperationException e) {
+            FulibFxApp.LOGGER.severe("Could not initialize mouse handler reflection. This may cause problems with mouse drag events.");
+        }
     }
 
     /**
@@ -86,4 +102,22 @@ public class ReflectionUtil {
         }
     }
 
+    /**
+     * Resets the mouse handler of the given stage. This method is used to reset the mouse handler of a scene to avoid
+     * problems with mouse drag events. This should be used with caution and is mainly used for refreshing the scene.
+     *
+     * @param stage The stage to reset the mouse handler for
+     */
+    public static void resetMouseHandler(Stage stage) {
+        // NB: This hack avoids problems with mouse drag events.
+        // In particular, the scene's MouseHandler would keep a list of its previous nodes,
+        // which do not have a reference back to the scene and subsequently cause an NPE.
+        try {
+            final Scene scene = stage.getScene();
+            final Object mouseHandler = mouseHandlerCtor.newInstance(scene);
+            mouseHandlerField.set(scene, mouseHandler);
+        } catch (ReflectiveOperationException e) {
+            FulibFxApp.LOGGER.warning("Could not reset mouse handler. This may cause problems with mouse drag events after refreshing the scene.");
+        }
+    }
 }


### PR DESCRIPTION
Fixes an issue where the mouse handler keeps a list of its previous nodes, which do not have a reference back to the scene and subsequently cause an NPE.

As this is a reflection hack, it should be tested carefully in applications.

Originally authored by @Clashsoft, cherry picked from https://github.com/fujaba/fulibFx/tree/stp-24 by @LeStegii.