### PR TITLE
Add suggestions for non-relative routes

### DIFF
--- a/framework/src/main/java/org/fulib/fx/controller/Router.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Router.java
@@ -96,7 +96,7 @@ public class Router {
         // Check if the route exists and has a valid controller
         if (!this.routes.containsPath(route)) {
             if (FrameworkUtil.runningInDev() && this.routes.containsPath("/" + route))
-                FulibFxApp.LOGGER.warning("This route doesn't exist. Did you mean '/%s' instead of '%s'?".formatted(route, route));
+                FulibFxApp.LOGGER.warning("This route doesn't exist. Did you mean '/%s'?".formatted(route));
             throw new ControllerInvalidRouteException(route);
         }
 


### PR DESCRIPTION
When an invalid route is entered, the framework now checks if `"/" + route` would be valid and prints a warning in the console if dev mode is active.
This should help to find issues with relative routes.

Closes #35 
