### PR TITLE
Fix links in markdown files

### DIFF
--- a/docs/controller/9-call-order.md
+++ b/docs/controller/9-call-order.md
@@ -7,7 +7,7 @@ The framework has a general rule of **initialization before rendering**, meaning
 elements (for example nodes defined in an FXML file) in the init methods as the elements aren't loaded before the
 rendering.
 
-When using subcomponents or [For-Loops](../features/2-for), the order of operations is a bit more complex. At first the main controller
+When using subcomponents or [For-Loops](../features/2-for.md), the order of operations is a bit more complex. At first the main controller
 will be initialized. After the controller has been initialized, all subcomponents will be loaded and therefore
 initialized. This will happen recursively until a subcomponent doesn't have any subcomponents. After that, the
 subcomponents will be rendered, going back up to the main controller. The main controller will be rendered, after all

--- a/docs/controller/README.md
+++ b/docs/controller/README.md
@@ -4,13 +4,13 @@ Controllers are the backbone of the application.
 They are responsible for handling the requests and responses and for processing the data and rendering the view.
 This section will give you an overview of the controllers and components and how to use them.
 
-1. [Controllers](1-controllers)
-2. [Components](2-components)
-3. [Views](3-views)
-4. [Parameters](4-parameters)
-5. [Internationalization](5-internationalization)
-6. [Titles](6-titles)
-7. [Routing](7-routing)
-8. [Subcomponents](8-subcomponents)
-9. [Call order](9-call-order)
-10. [Key events](10-key-events)
+1. [Controllers](1-controllers.md)
+2. [Components](2-components.md)
+3. [Views](3-views.md)
+4. [Parameters](4-parameters.md)
+5. [Internationalization](5-internationalization.md)
+6. [Titles](6-titles.md)
+7. [Routing](7-routing.md)
+8. [Subcomponents](8-subcomponents.md)
+9. [Call order](9-call-order.md)
+10. [Key events](10-key-events.md)

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -3,8 +3,8 @@
 The framework provides a number of features to help you build your application. 
 This section will give you an overview of the features and how to use them.
 
-1. [Subscriber](1-subscriber)
-2. [For-Loop](2-for)
-3. [History and refresh](3-history)
-4. [Modals](4-modals)
-5. [Node Duplicator](5-node-duplicator)
+1. [Subscriber](1-subscriber.md)
+2. [For-Loop](2-for.md)
+3. [History and refresh](3-history.md)
+4. [Modals](4-modals.md)
+5. [Node Duplicator](5-node-duplicator.md)


### PR DESCRIPTION
This should fix all the broken links.

Closes #77 