### PR TITLE
Add checks for private fields/methods during the annotation processor

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -181,7 +181,7 @@ show(new MyComponent()); // Wrong, should not be able to show a controller that 
 ### 1012: `Cannot access private * '*' in class '*' annotated with '*'.`
 
 - Runtime: ✅
-- Annotation Processor: ❌ (Caught by the compiler)
+- Annotation Processor: ✅ (Caught by the compiler)
 
 This error is thrown when the framework tries to access a private field or method.
 

--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -181,7 +181,7 @@ show(new MyComponent()); // Wrong, should not be able to show a controller that 
 ### 1012: `Cannot access private * '*' in class '*' annotated with '*'.`
 
 - Runtime: ✅
-- Annotation Processor: ✅ (Caught by the compiler)
+- Annotation Processor: ✅
 
 This error is thrown when the framework tries to access a private field or method.
 

--- a/annotation-processor/src/main/java/org/fulib/fx/FxClassGenerator.java
+++ b/annotation-processor/src/main/java/org/fulib/fx/FxClassGenerator.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Stream;
 
@@ -358,7 +359,7 @@ public class FxClassGenerator {
     private Stream<ExecutableElement> streamAllMethods(TypeElement componentClass, Class<? extends Annotation> annotation) {
         return streamSuperClasses(componentClass).flatMap(e -> streamMethods(e, annotation)).peek(field -> {
             if (field.getModifiers().contains(Modifier.PRIVATE)) {
-                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error(1012).formatted(Field.class.getSimpleName(), field.getSimpleName(), componentClass.getQualifiedName(), annotation.getSimpleName(), field));
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error(1012).formatted(Method.class.getSimpleName(), field.getSimpleName(), componentClass.getQualifiedName(), annotation.getSimpleName(), field));
             }
         });
     }

--- a/annotation-processor/src/main/java/org/fulib/fx/FxClassGenerator.java
+++ b/annotation-processor/src/main/java/org/fulib/fx/FxClassGenerator.java
@@ -17,12 +17,16 @@ import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.ExecutableType;
 import javax.lang.model.type.TypeMirror;
+import javax.tools.Diagnostic;
 import javax.tools.JavaFileObject;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
 import java.util.*;
 import java.util.stream.Stream;
+
+import static org.fulib.fx.util.FrameworkUtil.error;
 
 public class FxClassGenerator {
     private static final String CLASS_SUFFIX = "_Fx";
@@ -350,8 +354,13 @@ public class FxClassGenerator {
         return processingEnv.getElementUtils().getConstantExpression(value);
     }
 
+    // This will throw an error if the methods are private
     private Stream<ExecutableElement> streamAllMethods(TypeElement componentClass, Class<? extends Annotation> annotation) {
-        return streamSuperClasses(componentClass).flatMap(e -> streamMethods(e, annotation));
+        return streamSuperClasses(componentClass).flatMap(e -> streamMethods(e, annotation)).peek(field -> {
+            if (field.getModifiers().contains(Modifier.PRIVATE)) {
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error(1012).formatted(Field.class.getSimpleName(), field.getSimpleName(), componentClass.getQualifiedName(), annotation.getSimpleName(), field));
+            }
+        });
     }
 
     private Stream<ExecutableElement> streamMethods(TypeElement componentClass, Class<? extends Annotation> annotation) {
@@ -362,8 +371,13 @@ public class FxClassGenerator {
             .map(element -> (ExecutableElement) element);
     }
 
+    // This will throw an error if the fields are private
     private Stream<VariableElement> streamAllFields(TypeElement componentClass, Class<? extends Annotation> annotation) {
-        return streamSuperClasses(componentClass).flatMap(e -> streamFields(e, annotation));
+        return streamSuperClasses(componentClass).flatMap(e -> streamFields(e, annotation)).peek(field -> {
+            if (field.getModifiers().contains(Modifier.PRIVATE)) {
+                processingEnv.getMessager().printMessage(Diagnostic.Kind.ERROR, error(1012).formatted(Field.class.getSimpleName(), field.getSimpleName(), componentClass.getQualifiedName(), annotation.getSimpleName(), field));
+            }
+        });
     }
 
     private Stream<VariableElement> streamFields(TypeElement componentClass, Class<? extends Annotation> annotation) {

--- a/ludo/build.gradle
+++ b/ludo/build.gradle
@@ -52,7 +52,7 @@ jar {
         attributes(
                 "Manifest-Version": 1.0,
                 "Class-Path": ".",
-                "Main-Class": "io.github.sekassel.person.Main"
+                "Main-Class": "de.uniks.ludo.LudoMain"
         )
     }
 


### PR DESCRIPTION
- Add checks for private fields/methods during the annotation processor
- Fix incorrect class name in manifest in build gradle

Closes #83
Closes #79 