### PR TITLE
Add default parameters to modals

### DIFF
--- a/docs/features/4-modals.md
+++ b/docs/features/4-modals.md
@@ -4,16 +4,41 @@ Modals are a special type of window that can be used to display a controller on 
 can be used to display popup windows, dialogs, etc.
 
 The framework provides a `Modals` class that can be used to display a modal.
+When using `showModal()` a stage will be created and configured to be displayed above the current stage.
+A BiConsumer provides access to the component instance and the stage for configuring other things.
+
+When displaying the component, the parameters `modalStage` and `ownerStage` will be passed so that the modal can for
+example be closed from inside the component class.
 
 ```java
-Modals.showModal(app, confirmComponent, (stage, component) -> {
-    stage.setTitle("Modal");
-    component.setConfirmAction(() -> {
-        // Do something
-        stage.close();
-    });
-});
 
+@Component
+public class ModalComponent extends VBox {
+
+    // ...
+
+    @Param("modalStage")
+    Stage modal;
+
+    @OnRender
+    void onRender() {
+        modal.setTitle("Modal");
+    }
+
+    @FXML
+    void onCloseClick() {
+        doStuff();
+        modal.close();
+    }
+
+}
+```
+
+```java
+Modals.showModal(app, modalComponent, (stage, component) -> {
+    stage.doSomething();
+    component.doSomethingElse();
+});
 ```
 
 ---

--- a/docs/features/README.md
+++ b/docs/features/README.md
@@ -8,3 +8,4 @@ This section will give you an overview of the features and how to use them.
 3. [History and refresh](3-history.md)
 4. [Modals](4-modals.md)
 5. [Node Duplicator](5-node-duplicator.md)
+6. [Component List Cell](7-componentlistcell.md)

--- a/framework/src/main/java/org/fulib/fx/controller/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Modals.java
@@ -173,7 +173,7 @@ public class Modals {
             ModalStage modalStage = new ModalStage(app, destroyOnClose, component);
 
             Map<String, Object> parameters = new HashMap<>(params);
-            parameters.putIfAbsent("stage", modalStage);
+            parameters.putIfAbsent("modalStage", modalStage);
             parameters.putIfAbsent("ownerStage", currentStage);
 
             app.frameworkComponent().controllerManager().init(component, parameters);

--- a/framework/src/main/java/org/fulib/fx/controller/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Modals.java
@@ -11,6 +11,7 @@ import javafx.stage.StageStyle;
 import org.fulib.fx.FulibFxApp;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
@@ -171,8 +172,12 @@ public class Modals {
         FulibFxApp.FX_SCHEDULER.scheduleDirect(() -> {
             ModalStage modalStage = new ModalStage(app, destroyOnClose, component);
 
-            app.frameworkComponent().controllerManager().init(component, params);
-            Node rendered = app.frameworkComponent().controllerManager().render(component, params);
+            Map<String, Object> parameters = new HashMap<>(params);
+            parameters.putIfAbsent("stage", modalStage);
+            parameters.putIfAbsent("ownerStage", currentStage);
+
+            app.frameworkComponent().controllerManager().init(component, parameters);
+            Node rendered = app.frameworkComponent().controllerManager().render(component, parameters);
 
             if (!(rendered instanceof Parent parent)) {
                 throw new IllegalArgumentException(error(1011).formatted(component.getClass().getName()));

--- a/framework/src/main/java/org/fulib/fx/controller/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Modals.java
@@ -172,20 +172,26 @@ public class Modals {
         FulibFxApp.FX_SCHEDULER.scheduleDirect(() -> {
             ModalStage modalStage = new ModalStage(app, destroyOnClose, component);
 
+            // Add additional default parameters
             Map<String, Object> parameters = new HashMap<>(params);
             parameters.putIfAbsent("modalStage", modalStage);
             parameters.putIfAbsent("ownerStage", currentStage);
 
+            // Initialize and render the component
             app.frameworkComponent().controllerManager().init(component, parameters);
             Node rendered = app.frameworkComponent().controllerManager().render(component, parameters);
 
+            // As the displayed component will be the root of a stage, it has to be a parent
             if (!(rendered instanceof Parent parent)) {
                 throw new IllegalArgumentException(error(1011).formatted(component.getClass().getName()));
             }
 
+            // Set the title if present
+            app.getTitle(component).ifPresent(title -> modalStage.setTitle(app.formatTitle(title)));
+
+            // Configure scene to look like a popup (can be changed using the initializer)
             Scene scene = new Scene(parent);
             scene.setFill(Paint.valueOf("transparent"));
-
             modalStage.setScene(scene);
             modalStage.initStyle(StageStyle.TRANSPARENT);
             modalStage.initOwner(currentStage);


### PR DESCRIPTION
# Default Modal parameters
"stage" and "ownerStage" will now be passed to components as default parameters when showing them using modals

This allows for closing the modal stage from inside the component. It also allows for checking whether the component is displayed in a modal or not.

# Comparison

## Old (1)
The example given in the docs currently uses the biconsumer to add logic to the close button.
This however has the downside of having to define the entire button logic outside the component.

```java
@Component(view = "Modal.fxml")
public class ModalComponent extends VBox {

    @FXML
    public Button closeButton;

    // ...

}
```

```java
Modals.showModal(app, modalComponent, (stage, component) -> component.closeButton.setOnAction(event -> stage.close()));
```

## Old (2)
If the component has some complex logic which should not be defined from the outside, one could use a runnable.
This would solve the issue of having to define actions from the outside, but still requires boilerplate code.

```java
@Component(view = "Modal.fxml")
public class ModalComponent extends VBox {

    private Runnable onClose;

    public void setOnClose(Runnable onClose) {
        this.onClose = onClose;
    }

    @FXML
    void onCloseClick() {
        this.doImportantStuff();
        this.onClose.run();
    }

    // ...
}
```

```java
Modals.showModal(app, modalComponent, (stage, component) -> component.setOnClose(stage::close));
```

## New
Now the stage (and the owner stage) will be passed as parameters, allowing for the stage to be closed from the inside of the component. This removes a lot of otherwise required boilerplate code.

```java
@Component(view = "Modal.fxml")
public class ModalComponent extends VBox {

    @Param("modalStage") Stage modal;

    @FXML
    void onCloseClick() {
        this.doImportantStuff();
        this.modal.close()
    }

    // ...
}
```

```java
Modals.showModal(app, modalComponent);
```