### PR TITLE
Enhance ludo tests

### DIFF
--- a/ludo/build.gradle
+++ b/ludo/build.gradle
@@ -36,6 +36,7 @@ dependencies {
     testImplementation group: 'org.testfx', name: 'openjfx-monocle', version: monocleVersion
     testImplementation group: 'org.mockito', name: 'mockito-junit-jupiter', version: mockitoVersion
     testAnnotationProcessor group: 'com.google.dagger', name: 'dagger-compiler', version: daggerVersion
+    testImplementation group: 'org.hamcrest', name: 'hamcrest', version: hamcrestVersion
 }
 
 java {

--- a/ludo/src/main/java/de/uniks/ludo/App.java
+++ b/ludo/src/main/java/de/uniks/ludo/App.java
@@ -73,7 +73,9 @@ public class App extends FulibFxApp {
             setDefaultResourceBundle(component.bundle());
 
             // Starting the application by showing the main view without any parameters
-            show("");
+            if (!LudoUtil.inControllerTest()) {
+                show("");
+            }
 
         } catch (Exception e) {
             // If an error occurs while starting the application, we want to log it and exit the application

--- a/ludo/src/main/java/de/uniks/ludo/LudoUtil.java
+++ b/ludo/src/main/java/de/uniks/ludo/LudoUtil.java
@@ -5,6 +5,16 @@ import javafx.scene.media.MediaPlayer;
 
 public class LudoUtil {
 
+    private static final String CONTROLLER_TEST = "controller.test.enabled";
+
+    public static boolean inControllerTest() {
+        return Boolean.parseBoolean(System.getProperty(CONTROLLER_TEST));
+    }
+
+    public static void enableControllerTest() {
+        System.setProperty(CONTROLLER_TEST, Boolean.toString(true));
+    }
+
     /**
      * Plays a media/sound.
      *

--- a/ludo/src/test/java/de/uniks/ludo/ControllerTest.java
+++ b/ludo/src/test/java/de/uniks/ludo/ControllerTest.java
@@ -13,6 +13,7 @@ public class ControllerTest extends ApplicationTest {
 
     @Override
     public void start(Stage stage) throws Exception {
+        LudoUtil.enableControllerTest();
         super.start(stage);
         this.stage = stage;
         stage.requestFocus();


### PR DESCRIPTION
- Fix tests not running on some occasions
- Disable showing the default route in controller tests

Until now, the setup controller was created, initialized, rendered, displayed and then destroyed every time a controller test was run. This PR adds a check to disable the `show` call in the app startup if the app is run inside a controller test.