### PR TITLE
Update title upon refresh

### DIFF
--- a/framework/src/main/java/org/fulib/fx/FulibFxApp.java
+++ b/framework/src/main/java/org/fulib/fx/FulibFxApp.java
@@ -279,7 +279,7 @@ public abstract class FulibFxApp extends Application {
      */
     protected void prepareDisplay(@Nullable String route, @NotNull Parent parent, @NotNull Object controller, @NotNull Map<String, Object> params) {
         this.currentMainController = controller;
-        getTitle(currentMainController).ifPresent(title -> stage.setTitle(formatTitle(title)));
+        applyTitle(currentMainController, stage);
         display(parent);
         onShow(Optional.ofNullable(route), controller, parent, params);
     }
@@ -406,8 +406,8 @@ public abstract class FulibFxApp extends Application {
             throw new IllegalArgumentException(error(1011).formatted(controller.getClass().getName()));
         }
         ReflectionUtil.resetMouseHandler(stage());
-        getTitle(controller).ifPresent(title -> stage.setTitle(formatTitle(title)));
-        display(parent); // Display the controller
+        applyTitle(controller, stage());
+        display(parent);
     }
 
     /**
@@ -448,6 +448,16 @@ public abstract class FulibFxApp extends Application {
      */
     public Optional<String> getTitle(Object controller) {
         return this.frameworkComponent.controllerManager().getTitle(controller);
+    }
+
+    /**
+     * Applies the title of the given controller to the stage.
+     *
+     * @param controller The controller instance
+     * @param stage      The stage to apply the title to
+     */
+    public void applyTitle(Object controller, Stage stage) {
+        getTitle(controller).ifPresent(title -> stage.setTitle(formatTitle(title)));
     }
 
     /**

--- a/framework/src/main/java/org/fulib/fx/FulibFxApp.java
+++ b/framework/src/main/java/org/fulib/fx/FulibFxApp.java
@@ -406,7 +406,7 @@ public abstract class FulibFxApp extends Application {
             throw new IllegalArgumentException(error(1011).formatted(controller.getClass().getName()));
         }
         ReflectionUtil.resetMouseHandler(stage());
-        display(parent);
+        getTitle(controller).ifPresent(title -> stage.setTitle(formatTitle(title)));
     }
 
     /**

--- a/framework/src/main/java/org/fulib/fx/FulibFxApp.java
+++ b/framework/src/main/java/org/fulib/fx/FulibFxApp.java
@@ -407,6 +407,7 @@ public abstract class FulibFxApp extends Application {
         }
         ReflectionUtil.resetMouseHandler(stage());
         getTitle(controller).ifPresent(title -> stage.setTitle(formatTitle(title)));
+        display(parent); // Display the controller
     }
 
     /**

--- a/framework/src/main/java/org/fulib/fx/controller/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Modals.java
@@ -187,7 +187,7 @@ public class Modals {
             }
 
             // Set the title if present
-            app.getTitle(component).ifPresent(title -> modalStage.setTitle(app.formatTitle(title)));
+            app.applyTitle(component, modalStage);
 
             // Configure scene to look like a popup (can be changed using the initializer)
             Scene scene = new Scene(parent);


### PR DESCRIPTION
## Improvements
This PR fixes an issue with not updating the application title upon calling `refresh()`.

Before, the title only changed upon calling `show()` as this called `prepareDisplay()` internally, which then changed the title.
`refresh()` however doesn't call `prepareDisplay()` and therefore didn't change the title.
Now `refresh()` will change the title as well. 

## Other
Maybe `refresh()` could use `prepareDisplay()` as well, but this calls the `onShow()` event method which might not be wanted during refresh. Open for feedback on this though.