### PR TITLE
Catch inaccessible object error in reflection utils

### DIFF
--- a/framework/src/main/java/org/fulib/fx/util/ReflectionUtil.java
+++ b/framework/src/main/java/org/fulib/fx/util/ReflectionUtil.java
@@ -37,7 +37,7 @@ public class ReflectionUtil {
             mouseHandlerCtor = Class.forName(Scene.class.getName() + "$MouseHandler").getDeclaredConstructor(Scene.class);
             mouseHandlerField.setAccessible(true);
             mouseHandlerCtor.setAccessible(true);
-        } catch (ReflectiveOperationException e) {
+        } catch (ReflectiveOperationException | InaccessibleObjectException e) {
             FulibFxApp.LOGGER.severe("Could not initialize mouse handler reflection. This may cause problems with mouse drag events.");
         }
     }


### PR DESCRIPTION
Catch inaccessible object error in reflection utils.
This doesn't really fix the issue when using `./gradlew run` but displays the correct error message instead of just not compiling the application.

Closes #95 