### PR TITLE
Remove System.exit from FulibFxApp.stop

### DIFF
--- a/framework/src/main/java/org/fulib/fx/FulibFxApp.java
+++ b/framework/src/main/java/org/fulib/fx/FulibFxApp.java
@@ -206,7 +206,6 @@ public abstract class FulibFxApp extends Application {
     public void stop() {
         cleanup();
         autoRefresher().close();
-        System.exit(0);
     }
 
     /**

--- a/framework/src/test/java/org/fulib/fx/mocking/ControllerTest.java
+++ b/framework/src/test/java/org/fulib/fx/mocking/ControllerTest.java
@@ -7,7 +7,7 @@ import org.testfx.framework.junit5.ApplicationTest;
 public class ControllerTest extends ApplicationTest {
 
     @Spy
-    public final MyApp app = new MyApp();
+    protected MyApp app = new MyApp();
 
     protected Stage stage;
 
@@ -17,5 +17,13 @@ public class ControllerTest extends ApplicationTest {
         this.stage = stage;
         stage.requestFocus();
         app.start(stage);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        super.stop();
+        app.stop();
+        app = null;
+        stage = null;
     }
 }

--- a/ludo/src/test/java/de/uniks/ludo/ControllerTest.java
+++ b/ludo/src/test/java/de/uniks/ludo/ControllerTest.java
@@ -7,7 +7,7 @@ import org.testfx.framework.junit5.ApplicationTest;
 public class ControllerTest extends ApplicationTest {
 
     @Spy
-    public final App app = new App();
+    protected App app = new App();
 
     protected Stage stage;
 
@@ -17,5 +17,13 @@ public class ControllerTest extends ApplicationTest {
         this.stage = stage;
         stage.requestFocus();
         app.start(stage);
+    }
+
+    @Override
+    public void stop() throws Exception {
+        super.stop();
+        app.stop();
+        app = null;
+        stage = null;
     }
 }


### PR DESCRIPTION
## Bugfixes

* `FulibFxApp.stop` no longer calls `System.exit`.

This makes it possible to actually stop/ clean up the app in tests, which is very important to avoid OOM errors.
