### PR TITLE
Rework modals

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -205,7 +205,8 @@ public class MyController {
 - Runtime: ✅
 - Annotation Processor: ✅
 
-This error if an event method overrides another event method as this would lead to the overriding method being called twice.
+This error is thrown if an event method overrides another event method as this would lead to the overriding method being 
+called twice.
 
 ```java
 public class MyController extends BaseController {
@@ -229,6 +230,14 @@ public class BaseController {
     // ...
 }
 ```
+
+### 1014: `The same component instance can only be included in one scene.`
+
+- Runtime: ✅
+- Annotation Processor: ❌
+
+This error is thrown when a component instance that is already included in a scene is used in a modal.
+A node can only be included in one scene, therefore using an already used component instance in a modal
 
 ## Resources
 

--- a/docs/features/4-modals.md
+++ b/docs/features/4-modals.md
@@ -4,8 +4,20 @@ Modals are a special type of window that can be used to display a controller on 
 can be used to display popup windows, dialogs, etc.
 
 The framework provides a `Modals` class that can be used to display a modal.
-When using `showModal()` a stage will be created and configured to be displayed above the current stage.
-A BiConsumer provides access to the component instance and the stage for configuring other things.
+Using a builder, a stage can be configured and then be displayed.
+
+A BiConsumer provides access to the component instance and the stage for configuring things the builder doesn't provide.
+It can be set using `init()`.
+
+Enabling `dialog()` adds some default styling to the stage.
+This has been added as an option to enable the legacy default styling present in the old modal class.
+
+Parameters can be passed by using the `param()` method in form of a map (see `show()` in the `FulibFxApp` class).
+
+Enabling `destroyOnClose()` configures the component to be destroyed upon closing the modal. 
+This is enabled by default and shouldn't be changed if not necessary.
+
+The stage can either be built using `build()` and then displayed by yourself, or built and displayed at once using `show()`.
 
 When displaying the component, the parameters `modalStage` and `ownerStage` will be passed so that the modal can for
 example be closed from inside the component class.
@@ -37,11 +49,16 @@ public class ModalComponent extends VBox {
 ```
 
 ```java
-// As every modal needs its own instance, we use a provider (e.g. with Dagger)
-Modals.showModal(app, modalComponentProvider.get(), (stage, component) -> {
-    stage.doSomething();
-    component.doSomethingElse();
-});
+Modals modals = new Modals(app); // Can also be injected by Dagger
+
+modals
+    .modal(myModalComponent)
+    .dialog(true) // Apply the legacy fulibFx styling
+    .init((stage, component) -> {
+        stage.setTitle(component.getString());    
+    })
+    .params(Map.of("key", value))
+    .show();
 ```
 
 ---

--- a/framework/src/main/java/org/fulib/fx/constructs/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/constructs/Modals.java
@@ -6,6 +6,7 @@ import javafx.scene.Scene;
 import javafx.scene.paint.Paint;
 import javafx.stage.*;
 import org.fulib.fx.FulibFxApp;
+import org.fulib.fx.util.ControllerUtil;
 
 import javax.inject.Inject;
 import java.util.HashMap;
@@ -36,7 +37,10 @@ public class Modals {
      * @param <T>       The type of component
      * @return A modal instance
      */
-    public <T extends Node> ModalBuilder<T> modal(T component) {
+    public <T extends Parent> ModalBuilder<T> modal(T component) {
+        if (!ControllerUtil.isComponent(component)) {
+            throw new IllegalArgumentException(error(1000));
+        }
         return new ModalBuilder<>(app, component);
     }
 
@@ -46,7 +50,7 @@ public class Modals {
      *
      * @param <T> The type of the component
      */
-    public static class ModalBuilder<T extends Node> {
+    public static class ModalBuilder<T extends Parent> {
 
         /**
          * Initializes the stage with some default options like transparency and modality

--- a/framework/src/main/java/org/fulib/fx/constructs/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/constructs/Modals.java
@@ -139,10 +139,13 @@ public class Modals {
         }
 
         /**
-         * Displays the current modal.
+         * Builds the stage for the current modal.
+         * <p>
          * This can only be called once per modal builder.
+         *
+         * @return The stage for the current modal
          */
-        public Stage show() {
+        public Stage build() {
 
             if (component.getScene() != null) {
                 throw new RuntimeException(error(1014));
@@ -183,6 +186,18 @@ public class Modals {
             if (initializer != null) {
                 initializer.accept(modalStage, component);
             }
+            return modalStage;
+        }
+
+        /**
+         * Builds and displays the stage for the current modal.
+         * <p>
+         * This can only be called once per modal builder.
+         *
+         * @return The stage for the current modal
+         */
+        public Stage show() {
+            Stage modalStage = build();
             modalStage.show();
             modalStage.requestFocus();
             return modalStage;
@@ -196,10 +211,10 @@ public class Modals {
      */
     public static List<Stage> getModalStages() {
         return Window.getWindows()
-            .stream()
-            .filter(Modals::isModal)
-            .map(window -> (Stage) window)
-            .toList();
+                .stream()
+                .filter(Modals::isModal)
+                .map(window -> (Stage) window)
+                .toList();
     }
 
     public static boolean isModal(Window window) {

--- a/framework/src/main/java/org/fulib/fx/constructs/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/constructs/Modals.java
@@ -1,0 +1,158 @@
+package org.fulib.fx.constructs;
+
+import javafx.scene.Node;
+import javafx.scene.Parent;
+import javafx.scene.Scene;
+import javafx.scene.paint.Paint;
+import javafx.stage.Modality;
+import javafx.stage.Stage;
+import javafx.stage.StageStyle;
+import javafx.stage.Window;
+import org.fulib.fx.FulibFxApp;
+import org.jetbrains.annotations.NotNull;
+
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import static org.fulib.fx.util.FrameworkUtil.error;
+
+public class Modals {
+
+    @Inject
+    FulibFxApp app;
+
+    @Inject
+    public Modals() {
+    }
+
+    public Modals(FulibFxApp app) {
+        this.app = app;
+    }
+
+    public <T extends Node> Modal<T> modal(T component) {
+        return new Modal<>(app, component);
+    }
+
+
+    public static class Modal<T extends Node> {
+
+        private final BiConsumer<Stage, T> FULIBFX_DIALOG = ((modalStage, component) -> {
+            modalStage.initStyle(StageStyle.TRANSPARENT);
+            modalStage.initModality(Modality.WINDOW_MODAL);
+            modalStage.setAlwaysOnTop(true);
+        });
+
+        private final T component;
+        private final FulibFxApp app;
+
+        private BiConsumer<Stage, T> initializer = (stage, component) -> {
+        };
+        private Stage owner;
+        private Map<String, Object> params = new HashMap<>();
+        private boolean destroyOnClose = true;
+
+        public Modal(FulibFxApp app, T component) {
+            this.app = app;
+            this.component = component;
+            this.owner = app.stage();
+        }
+
+        public Modal<T> init(BiConsumer<Stage, T> initializer) {
+            this.initializer = initializer;
+            return this;
+        }
+
+        public Modal<T> owner(Stage owner) {
+            this.owner = owner;
+            return this;
+        }
+
+        public Modal<T> initDialog(BiConsumer<Stage, T> initializer) {
+            this.initializer = FULIBFX_DIALOG.andThen(initializer);
+            return this;
+        }
+
+        public Modal<T> params(Map<String, Object> params) {
+            this.params = params;
+            return this;
+        }
+
+        public Modal<T> destroyOnClose(boolean destroyOnClose) {
+            this.destroyOnClose = destroyOnClose;
+            return this;
+        }
+
+        public void show() {
+            FulibFxApp.FX_SCHEDULER.scheduleDirect(() -> {
+                ModalStage modalStage = new ModalStage(app, destroyOnClose, component);
+
+                // Add additional default parameters
+                Map<String, Object> parameters = new HashMap<>(params);
+                parameters.putIfAbsent("modalStage", modalStage);
+                parameters.putIfAbsent("ownerStage", owner);
+
+                // Initialize and render the component
+                app.frameworkComponent().controllerManager().init(component, parameters);
+                Node rendered = app.frameworkComponent().controllerManager().render(component, parameters);
+
+                // As the displayed component will be the root of a stage, it has to be a parent
+                if (!(rendered instanceof Parent parent)) {
+                    throw new IllegalArgumentException(error(1011).formatted(component.getClass().getName()));
+                }
+
+                // Set the title if present
+                app.applyTitle(component, modalStage);
+
+                // Configure scene to look like a popup (can be changed using the initializer)
+                Scene scene = new Scene(parent);
+                scene.setFill(Paint.valueOf("transparent"));
+                modalStage.setScene(scene);
+                modalStage.initOwner(owner);
+                initializer.accept(modalStage, component);
+                modalStage.show();
+                modalStage.requestFocus();
+            });
+        }
+    }
+
+    /**
+     * Slightly modified version of {@link Stage} that destroys the controller when the stage is hidden.
+     */
+    public static class ModalStage extends Stage {
+
+        private final FulibFxApp app;
+        private final Object component;
+        private final boolean destroyOnClose;
+
+        public ModalStage(FulibFxApp app, boolean destroyOnClose, @NotNull Object component) {
+            super();
+            this.destroyOnClose = destroyOnClose;
+            this.app = app;
+            this.component = component;
+        }
+
+        @Override
+        public void hide() {
+            if (destroyOnClose) app.frameworkComponent().controllerManager().destroy(component);
+            super.hide();
+        }
+
+    }
+
+    /**
+     * Returns a list of all visible modal stages
+     *
+     * @return A list of all visible modal stages
+     */
+    public static List<ModalStage> getModalStages() {
+        return Window.getWindows()
+                .stream()
+                .filter(window -> window instanceof ModalStage)
+                .map(window -> (ModalStage) window)
+                .toList();
+    }
+
+}

--- a/framework/src/main/java/org/fulib/fx/controller/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Modals.java
@@ -164,7 +164,7 @@ public class Modals {
         org.fulib.fx.constructs.Modals modals = new org.fulib.fx.constructs.Modals(app);
         modals.modal(component)
                 .owner(currentStage)
-                .initDialog(initializer)
+                .dialog(true)
                 .params(params)
                 .destroyOnClose(destroyOnClose)
                 .show();

--- a/framework/src/main/java/org/fulib/fx/controller/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Modals.java
@@ -1,7 +1,6 @@
 package org.fulib.fx.controller;
 
 import javafx.event.EventHandler;
-import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.stage.Stage;
 import org.fulib.fx.FulibFxApp;
@@ -166,7 +165,7 @@ public class Modals {
      * @param params       the parameters to pass to the controller
      * @param <Display>    the type of the controller
      */
-    public static <Display extends Node> void showModal(FulibFxApp app, Stage currentStage, Display component, BiConsumer<Stage, Display> initializer, Map<String, Object> params, boolean destroyOnClose) {
+    public static <Display extends Parent> void showModal(FulibFxApp app, Stage currentStage, Display component, BiConsumer<Stage, Display> initializer, Map<String, Object> params, boolean destroyOnClose) {
         org.fulib.fx.constructs.Modals modals = new org.fulib.fx.constructs.Modals(app);
         modals.modal(component)
                 .owner(currentStage)

--- a/framework/src/main/java/org/fulib/fx/controller/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Modals.java
@@ -9,6 +9,12 @@ import org.fulib.fx.FulibFxApp;
 import java.util.Map;
 import java.util.function.BiConsumer;
 
+/**
+ * Helper class for creating modal windows.
+ *
+ * @deprecated Use {@link org.fulib.fx.constructs.Modals} instead.
+ */
+@Deprecated(forRemoval = true)
 public class Modals {
 
     private Modals() {

--- a/framework/src/main/java/org/fulib/fx/controller/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Modals.java
@@ -171,6 +171,7 @@ public class Modals {
         modals.modal(component)
                 .owner(currentStage)
                 .dialog(true)
+                .init(initializer)
                 .params(params)
                 .destroyOnClose(destroyOnClose)
                 .show();

--- a/framework/src/main/resources/org/fulib/fx/lang/error.properties
+++ b/framework/src/main/resources/org/fulib/fx/lang/error.properties
@@ -13,6 +13,7 @@
 1011=Controller '%s' must provide a parent as their view to be able to be shown as a root node.
 1012=Cannot access private %s '%s' annotated with an event annotation in class '%s'.
 1013=Method '%s' annotated with an event annotation in class '%s' overrides event method in class '%s'.
+1014=The same component instance can only be included in one scene.
 
 # Resources
 2000=Could not find resource '%s'.

--- a/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
+++ b/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
@@ -3,24 +3,23 @@ package org.fulib.fx.app;
 import javafx.application.Platform;
 import javafx.beans.property.SimpleStringProperty;
 import javafx.beans.property.StringProperty;
-import org.fulib.fx.FulibFxApp;
-import org.fulib.fx.app.controller.InvalidParamController;
-import org.fulib.fx.app.controller.types.BasicComponent;
-import org.fulib.fx.app.controller.ParamController;
-import org.fulib.fx.app.controller.TitleController;
-import org.fulib.fx.app.controller.history.AController;
-import org.fulib.fx.app.controller.history.BController;
-import org.fulib.fx.app.controller.history.CController;
-import org.fulib.fx.app.controller.ModalComponent;
-import org.fulib.fx.app.controller.subcomponent.basic.ButtonSubComponent;
-import org.fulib.fx.controller.Modals;
-import org.fulib.fx.controller.exception.ControllerInvalidRouteException;
-import org.fulib.fx.controller.exception.IllegalControllerException;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.scene.Node;
 import javafx.scene.layout.VBox;
 import javafx.stage.Stage;
+import org.fulib.fx.FulibFxApp;
+import org.fulib.fx.app.controller.InvalidParamController;
+import org.fulib.fx.app.controller.ModalComponent;
+import org.fulib.fx.app.controller.ParamController;
+import org.fulib.fx.app.controller.TitleController;
+import org.fulib.fx.app.controller.history.AController;
+import org.fulib.fx.app.controller.history.BController;
+import org.fulib.fx.app.controller.history.CController;
+import org.fulib.fx.app.controller.subcomponent.basic.ButtonSubComponent;
+import org.fulib.fx.app.controller.types.BasicComponent;
+import org.fulib.fx.constructs.Modals;
+import org.fulib.fx.controller.exception.ControllerInvalidRouteException;
 import org.junit.jupiter.api.Test;
 import org.testfx.framework.junit5.ApplicationTest;
 
@@ -166,20 +165,45 @@ public class FrameworkTest extends ApplicationTest {
         verifyThat("Basic Controller", Node::isVisible);
         sleep(200);
 
-        Modals.showModal(app, new ModalComponent(), (stage, controller) -> {
-            stage.setTitle("Modal");
-            stage.setWidth(200);
-            stage.setHeight(200);
-        });
+        ModalComponent component = new ModalComponent();
+
+        new Modals(app)
+                .modal(component)
+                .init((stage, modalComponent) -> stage.setTitle("Modal"))
+                .params(Map.of("key", "value"))
+                .show();
 
         waitForFxEvents();
 
-        Modals.ModalStage modal = (Modals.ModalStage) Stage.getWindows().stream().filter(window -> window instanceof Modals.ModalStage).map(window -> (Stage) window).findAny().orElse(null);
+        Stage modal = Modals.getModalStages().getFirst();
 
         assertNotNull(modal);
+        assertEquals("value", component.getValue());
         verifyThat("Modal Component", Node::isVisible);
-        assertEquals(200, modal.getWidth());
-        assertEquals(200, modal.getHeight());
+        assertEquals("Modal", modal.getTitle());
+    }
+
+    @Test
+    public void modalTestLegacy() {
+        runAndWait(() -> app.show("/controller/basic"));
+        verifyThat("Basic Controller", Node::isVisible);
+        sleep(200);
+
+        ModalComponent component = new ModalComponent();
+
+        org.fulib.fx.controller.Modals.showModal(app, component, (stage, controller) -> {
+            stage.setTitle("Modal");
+            stage.setWidth(200);
+            stage.setHeight(200);
+        }, Map.of("key", "value"), true);
+
+        waitForFxEvents();
+
+        Stage modal = Modals.getModalStages().getFirst();
+
+        assertNotNull(modal);
+        assertEquals("value", component.getValue());
+        verifyThat("Modal Component", Node::isVisible);
         assertEquals("Modal", modal.getTitle());
     }
 

--- a/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
+++ b/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
@@ -175,7 +175,7 @@ public class FrameworkTest extends ApplicationTest {
 
         waitForFxEvents();
 
-        Stage modal = Modals.getModalStages().getFirst();
+        Stage modal = Modals.getModalStages().get(0);
 
         assertNotNull(modal);
         assertEquals("value", component.getValue());
@@ -188,6 +188,8 @@ public class FrameworkTest extends ApplicationTest {
     }
 
     @Test
+    @Deprecated
+    @SuppressWarnings("all")
     public void modalTestLegacy() {
         runAndWait(() -> app.show("/controller/basic"));
         verifyThat("Basic Controller", Node::isVisible);
@@ -203,7 +205,7 @@ public class FrameworkTest extends ApplicationTest {
 
         waitForFxEvents();
 
-        Stage modal = Modals.getModalStages().getFirst();
+        Stage modal = Modals.getModalStages().get(0);
 
         assertNotNull(modal);
         assertEquals("value", component.getValue());

--- a/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
+++ b/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
@@ -191,6 +191,18 @@ public class FrameworkTest extends ApplicationTest {
 
         assertTrue(component.destroyed);
 
+        ModalComponent component2 = new ModalComponent();
+
+        FX_SCHEDULER.scheduleDirect(() -> {
+            Stage built = new Modals(app)
+                    .modal(component2)
+                    .init((stage, modalComponent) -> stage.setTitle("Modal"))
+                    .build();
+            assertEquals("Modal", built.getTitle());
+        });
+
+        waitForFxEvents();
+
         FX_SCHEDULER.scheduleDirect(() -> assertThrows(RuntimeException.class, () -> new Modals(app).modal(component).show()));
     }
 

--- a/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
+++ b/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
@@ -179,12 +179,17 @@ public class FrameworkTest extends ApplicationTest {
 
         Stage modal = Modals.getModalStages().get(0);
 
+        assertTrue(Modals.isModal(modal));
+        assertFalse(Modals.isModal(app.stage()));
+
         assertNotNull(modal);
         assertEquals("value", component.getValue());
         verifyThat("Modal Component", Node::isVisible);
         assertEquals("Modal", modal.getTitle());
 
         runAndWait(modal::close);
+
+        assertTrue(component.destroyed);
 
         FX_SCHEDULER.scheduleDirect(() -> assertThrows(RuntimeException.class, () -> new Modals(app).modal(component).show()));
     }

--- a/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
+++ b/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
@@ -181,6 +181,10 @@ public class FrameworkTest extends ApplicationTest {
         assertEquals("value", component.getValue());
         verifyThat("Modal Component", Node::isVisible);
         assertEquals("Modal", modal.getTitle());
+
+        runAndWait(modal::close);
+
+        assertThrows(RuntimeException.class, () -> new Modals(app).modal(component).show());
     }
 
     @Test

--- a/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
+++ b/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
+import static org.fulib.fx.FulibFxApp.FX_SCHEDULER;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.testfx.api.FxAssert.verifyThat;
 import static org.testfx.util.WaitForAsyncUtils.waitForFxEvents;
@@ -119,7 +120,7 @@ public class FrameworkTest extends ApplicationTest {
     @Test
     public void simpleForTest() {
         ObservableList<String> list = FXCollections.observableList(new ArrayList<>());
-        FulibFxApp.FX_SCHEDULER.scheduleDirect(() -> {
+        FX_SCHEDULER.scheduleDirect(() -> {
             list.add("Hello");
             list.add("World");
             list.add("!");
@@ -131,12 +132,12 @@ public class FrameworkTest extends ApplicationTest {
         VBox container = lookup("#container").queryAs(VBox.class);
         assertEquals(3, container.getChildren().size());
 
-        FulibFxApp.FX_SCHEDULER.scheduleDirect(() -> list.remove("World"));
+        FX_SCHEDULER.scheduleDirect(() -> list.remove("World"));
         waitForFxEvents();
 
         assertEquals(2, container.getChildren().size());
 
-        FulibFxApp.FX_SCHEDULER.scheduleDirect(() -> list.add(1, "World"));
+        FX_SCHEDULER.scheduleDirect(() -> list.add(1, "World"));
         waitForFxEvents();
 
         assertEquals(3, container.getChildren().size());
@@ -167,11 +168,12 @@ public class FrameworkTest extends ApplicationTest {
 
         ModalComponent component = new ModalComponent();
 
-        new Modals(app)
-                .modal(component)
-                .init((stage, modalComponent) -> stage.setTitle("Modal"))
-                .params(Map.of("key", "value"))
-                .show();
+        FX_SCHEDULER.scheduleDirect(() -> new Modals(app)
+            .modal(component)
+            .init((stage, modalComponent) -> stage.setTitle("Modal"))
+            .params(Map.of("key", "value"))
+            .show()
+        );
 
         waitForFxEvents();
 
@@ -184,7 +186,7 @@ public class FrameworkTest extends ApplicationTest {
 
         runAndWait(modal::close);
 
-        assertThrows(RuntimeException.class, () -> new Modals(app).modal(component).show());
+        FX_SCHEDULER.scheduleDirect(() -> assertThrows(RuntimeException.class, () -> new Modals(app).modal(component).show()));
     }
 
     @Test
@@ -197,11 +199,11 @@ public class FrameworkTest extends ApplicationTest {
 
         ModalComponent component = new ModalComponent();
 
-        org.fulib.fx.controller.Modals.showModal(app, component, (stage, controller) -> {
+        FX_SCHEDULER.scheduleDirect(() -> org.fulib.fx.controller.Modals.showModal(app, component, (stage, controller) -> {
             stage.setTitle("Modal");
             stage.setWidth(200);
             stage.setHeight(200);
-        }, Map.of("key", "value"), true);
+        }, Map.of("key", "value"), true));
 
         waitForFxEvents();
 
@@ -218,11 +220,11 @@ public class FrameworkTest extends ApplicationTest {
         ParamController controller = new ParamController();
         StringProperty property = new SimpleStringProperty("string");
         Map<String, Object> params = Map.of(
-                "integer", 1,
-                "string", "string",
-                "character", 'a',
-                "bool", true,
-                "property", property
+            "integer", 1,
+            "string", "string",
+            "character", 'a',
+            "bool", true,
+            "property", property
         );
         runAndWait(() -> app.show(controller, params));
 
@@ -243,24 +245,24 @@ public class FrameworkTest extends ApplicationTest {
         assertEquals(property, controller.stringPropertyProperty());
 
         runAndWait(() ->
-                assertThrows(
-                        RuntimeException.class, // Fails because the field is of type Integer, but a String is provided
-                        () -> app.show(new InvalidParamController(), Map.of("one", "string"))
-                )
+            assertThrows(
+                RuntimeException.class, // Fails because the field is of type Integer, but a String is provided
+                () -> app.show(new InvalidParamController(), Map.of("one", "string"))
+            )
         );
 
         runAndWait(() ->
-                assertThrows(
-                        RuntimeException.class, // Fails because the property expects an Integer, but a String is provided
-                        () -> app.show(new InvalidParamController(), Map.of("two", "123"))
-                )
+            assertThrows(
+                RuntimeException.class, // Fails because the property expects an Integer, but a String is provided
+                () -> app.show(new InvalidParamController(), Map.of("two", "123"))
+            )
         );
 
         runAndWait(() ->
-                assertThrows(
-                        RuntimeException.class, // Fails because the property is null
-                        () -> app.show(new InvalidParamController(), Map.of("three", 123))
-                )
+            assertThrows(
+                RuntimeException.class, // Fails because the property is null
+                () -> app.show(new InvalidParamController(), Map.of("three", 123))
+            )
         );
     }
 
@@ -293,7 +295,7 @@ public class FrameworkTest extends ApplicationTest {
         runAndWait(app::back);
         verifyThat("B:b", Node::isVisible);
 
-        FulibFxApp.FX_SCHEDULER.scheduleDirect(app::refresh);
+        FX_SCHEDULER.scheduleDirect(app::refresh);
         waitForFxEvents();
         verifyThat("B:b", Node::isVisible);
     }

--- a/framework/src/test/java/org/fulib/fx/app/controller/ModalComponent.java
+++ b/framework/src/test/java/org/fulib/fx/app/controller/ModalComponent.java
@@ -3,15 +3,23 @@ package org.fulib.fx.app.controller;
 import org.fulib.fx.annotation.controller.Component;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
+import org.fulib.fx.annotation.param.Param;
 
 import javax.inject.Inject;
 
 @Component
 public class ModalComponent extends VBox {
 
+    @Param("key")
+    String value;
+
     @Inject
     public ModalComponent() {
         this.getChildren().add(new Label("Modal Component"));
+    }
+
+    public String getValue() {
+        return this.value;
     }
 
 }

--- a/framework/src/test/java/org/fulib/fx/app/controller/ModalComponent.java
+++ b/framework/src/test/java/org/fulib/fx/app/controller/ModalComponent.java
@@ -3,6 +3,7 @@ package org.fulib.fx.app.controller;
 import org.fulib.fx.annotation.controller.Component;
 import javafx.scene.control.Label;
 import javafx.scene.layout.VBox;
+import org.fulib.fx.annotation.event.OnDestroy;
 import org.fulib.fx.annotation.param.Param;
 
 import javax.inject.Inject;
@@ -13,6 +14,8 @@ public class ModalComponent extends VBox {
     @Param("key")
     String value;
 
+    public boolean destroyed;
+
     @Inject
     public ModalComponent() {
         this.getChildren().add(new Label("Modal Component"));
@@ -20,6 +23,11 @@ public class ModalComponent extends VBox {
 
     public String getValue() {
         return this.value;
+    }
+
+    @OnDestroy
+    public void onDestroy() {
+        destroyed = true;
     }
 
 }


### PR DESCRIPTION
- Rework modals to use a builder instead of static methods
- The old class still works as before, but has been deprecated and will likely be removed in the future
- Modals will not be configured by default anymore
- The modal initializer is now called before the modal is shown
- The framework now throws an error if the same component instance is used twice
- Updated tests
- Separated `build()` and `show()`