### PR TITLE
Remove Index Mode

### DIFF
--- a/ERROR_CODES.md
+++ b/ERROR_CODES.md
@@ -716,3 +716,26 @@ This error is thrown if closing the file watcher fails.
 
 This error is thrown if the framework fails to create a copy of an object because no duplicator has been registered for
 the object's class.
+
+### 9007: `Could not watch '*' - it does not exist or is not a directory.`
+
+- Runtime: ✅
+- Annotation Processor: ❌
+
+This error occurs when attempting to set up the `AutoRefresher` with an invalid path, or forgetting to disable it outside development mode.
+
+```java
+@Override
+public void start(Stage primaryStage) {
+    // ...
+
+    // Bad: (in production, the src directory will not exist)
+    autoRefresher().setup(Path.of("src/main/resources/de/uniks/ludo"));
+
+    // Good: (guarded by an environment variable)
+    if (System.getenv("AUTO_REFRESH") != null) {
+        autoRefresher().setup(Path.of("src/main/resources/de/uniks/ludo"));
+    }
+}
+```
+

--- a/framework/src/main/java/org/fulib/fx/controller/AutoRefresher.java
+++ b/framework/src/main/java/org/fulib/fx/controller/AutoRefresher.java
@@ -35,9 +35,8 @@ public class AutoRefresher {
 
     public void setup(Path directory) {
 
-        if (!FrameworkUtil.runningInDev()) {
-            FulibFxApp.LOGGER.warning("AutoRefresher is only meant to be used in development mode! Not starting.");
-            return;
+        if (!Files.isDirectory(directory)) {
+            throw new RuntimeException(error(9007).formatted(directory));
         }
 
         this.enabled = true;

--- a/framework/src/main/java/org/fulib/fx/controller/ControllerManager.java
+++ b/framework/src/main/java/org/fulib/fx/controller/ControllerManager.java
@@ -21,9 +21,7 @@ import org.fulib.fx.controller.internal.ReflectionSidecar;
 import org.fulib.fx.data.disposable.RefreshableCompositeDisposable;
 import org.fulib.fx.util.ControllerUtil;
 import org.fulib.fx.util.FileUtil;
-import org.fulib.fx.util.FrameworkUtil;
 import org.fulib.fx.util.KeyEventHolder;
-import org.fulib.fx.util.reflection.Reflection;
 import org.jetbrains.annotations.ApiStatus;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -207,24 +205,6 @@ public class ControllerManager {
 
         // TODO Unregister key events via Sidecar
         cleanUpListeners(instance);
-
-        // In development mode, check for undestroyed subscribers
-        if (FrameworkUtil.runningInDev()) {
-            Reflection.getAllFieldsOfType(instance.getClass(), Subscriber.class).forEach(field -> {  // Get all Subscriber fields
-                try {
-                    field.setAccessible(true);
-                    Subscriber subscriber = (Subscriber) field.get(instance); // Get the Subscriber instance, if it exists
-
-                    if (subscriber == null || subscriber.isDisposed() || subscriber.isFresh()) {
-                        return; // Check if the subscriber is disposed or non-existing
-                    }
-                    FulibFxApp.LOGGER.warning("Found undestroyed subscriber '%s' in class '%s'.".formatted(field.getName(), instance.getClass().getName()));
-
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException(error(9001).formatted(field.getName(), field.getDeclaringClass().getName()), e);
-                }
-            });
-        }
     }
 
     /**

--- a/framework/src/main/java/org/fulib/fx/controller/ControllerManager.java
+++ b/framework/src/main/java/org/fulib/fx/controller/ControllerManager.java
@@ -203,7 +203,6 @@ public class ControllerManager {
         }
         getSidecar(instance).destroy(instance);
 
-        // TODO Unregister key events via Sidecar
         cleanUpListeners(instance);
     }
 

--- a/framework/src/main/java/org/fulib/fx/controller/Router.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Router.java
@@ -99,7 +99,7 @@ public class Router {
     public @NotNull Pair<Object, Parent> renderRoute(@NotNull String route, @NotNull Map<@NotNull String, @Nullable Object> parameters) {
         // Check if the route exists and has a valid controller
         if (!this.routes.containsPath(route)) {
-            if (FrameworkUtil.runningInDev() && this.routes.containsPath("/" + route)) {
+            if (this.routes.containsPath("/" + route)) {
                 FulibFxApp.LOGGER.warning("This route doesn't exist. Did you mean '/%s'?".formatted(route));
             }
             throw new ControllerInvalidRouteException(route);

--- a/framework/src/main/java/org/fulib/fx/util/FrameworkUtil.java
+++ b/framework/src/main/java/org/fulib/fx/util/FrameworkUtil.java
@@ -11,20 +11,6 @@ public class FrameworkUtil {
         // Prevent instantiation
     }
 
-    // Environment variable for telling the framework that it's running in development mode
-    private static final String INDEV_ENVIRONMENT_VARIABLE = "INDEV";
-
-    /**
-     * Checks if the framework is running in development mode. This is the case if the INDEV environment variable is set to true.
-     * <p>
-     * Since people are dumb and might not set the variable correctly, it also checks if the intellij launcher is used.
-     *
-     * @return True if the framework is running in development mode
-     */
-    public static boolean runningInDev() {
-        return System.getenv().getOrDefault(INDEV_ENVIRONMENT_VARIABLE, "false").equalsIgnoreCase("true");
-    }
-
     public static String error(int id) {
         return ERROR_BUNDLE.getString(String.valueOf(id)) + " [FFX" + id + "]";
     }

--- a/framework/src/main/resources/org/fulib/fx/lang/error.properties
+++ b/framework/src/main/resources/org/fulib/fx/lang/error.properties
@@ -72,3 +72,4 @@
 9004=Couldn't start file service.
 9005=Couldn't close watcher.
 9006=No duplicator registered for '%s'.
+9007=Could not watch '%s' - it does not exist or is not a directory.


### PR DESCRIPTION
## Removals

* Removed Indev mode.

There were three use cases that can be implemented differently.
- AutoRefresher: It makes more sense to just check the given path for existence/being a directory, and let the user handle the conditions when the AutoRefresher is started. This avoids the pesky warning.
- Wrong Routes: There is no reason not to hint about that every time. Maybe we should change the mechanism to put the information in the exception message instead of a log message, in case there is some custom exception handling that would cause the log message to appear out of place.
- Undisposed Subscribers: This was a little out of place. It makes sense to integrate the Subscriber like this, but it should rather be an annotation processor warning that does not have a runtime cost.
