### PR TITLE
Rework onKey event options

### DIFF
--- a/annotation-processor/src/main/java/org/fulib/fx/FxClassGenerator.java
+++ b/annotation-processor/src/main/java/org/fulib/fx/FxClassGenerator.java
@@ -353,15 +353,23 @@ public class FxClassGenerator {
         out.printf("    controllerManager.addKeyEventHandler(instance, OnKey.Target.%s, OnKey.Type.%s.asEventType(), event -> {%n", onKey.target(), onKey.type());
         if (onKey.control()) {
             out.printf("      if (!event.isControlDown()) return;%n");
+        } else if (onKey.strict()) {
+            out.printf("      if (event.isControlDown()) return;%n");
         }
         if (onKey.shift()) {
             out.printf("      if (!event.isShiftDown()) return;%n");
+        } else if (onKey.strict()) {
+            out.printf("      if (event.isShiftDown()) return;%n");
         }
         if (onKey.alt()) {
             out.printf("      if (!event.isAltDown()) return;%n");
+        } else if (onKey.strict()) {
+            out.printf("      if (event.isAltDown()) return;%n");
         }
         if (onKey.meta()) {
             out.printf("      if (!event.isMetaDown()) return;%n");
+        } else if (onKey.strict()) {
+            out.printf("      if (event.isMetaDown()) return;%n");
         }
         if (onKey.code() != KeyCode.UNDEFINED) {
             out.printf("      if (event.getCode() != javafx.scene.input.KeyCode.%s) return;%n", onKey.code());

--- a/framework/src/main/java/org/fulib/fx/annotation/event/OnKey.java
+++ b/framework/src/main/java/org/fulib/fx/annotation/event/OnKey.java
@@ -70,9 +70,10 @@ public @interface OnKey {
 
     /**
      * Whether the settings for meta, control, alt and shift keys are strict.
-     *
+     * <ul>
      * <li> When strict mode is enabled, setting any of these options to false means the key must not be pressed.</li>
      * <li> When strict mode is disabled, setting any of these options to false means the key does not need to be pressed.</li>
+     * </ul>
      *
      * @return Whether the settings for meta, control, alt and shift keys are strict.
      */
@@ -81,8 +82,10 @@ public @interface OnKey {
     /**
      * The target at which the event should be handled.
      *
+     * <ul>
      * <li> STAGE: The event will be handled by the stage</li>
      * <li> SCENE: The event will be handled by the scene</li>
+     * </ul>
      *
      * @return The target at which the event should be handled
      */

--- a/framework/src/main/java/org/fulib/fx/annotation/event/OnKey.java
+++ b/framework/src/main/java/org/fulib/fx/annotation/event/OnKey.java
@@ -39,40 +39,50 @@ public @interface OnKey {
     String text() default "";
 
     /**
-     * Whether the shift key has to be pressed.
+     * Whether the shift key has to be pressed (see {@link OnKey#strict()}).
      *
      * @return Whether the shift key has to be pressed
      */
     boolean shift() default false;
 
     /**
-     * Whether the control key has to be pressed.
+     * Whether the control key has to be pressed (see {@link OnKey#strict()}).
      *
      * @return Whether the control key has to be pressed
      */
     boolean control() default false;
 
     /**
-     * Whether the alt key has to be pressed.
+     * Whether the alt key has to be pressed (see {@link OnKey#strict()}).
      *
      * @return Whether the alt key has to be pressed
      */
     boolean alt() default false;
 
     /**
-     * Whether the meta key has to be pressed.
+     * Whether the meta key has to be pressed (see {@link OnKey#strict()}).
      * The meta key is the command key on Mac and the control key on other platforms.
      *
      * @return Whether the meta key has to be pressed
      */
     boolean meta() default false;
 
+
+    /**
+     * Whether the settings for meta, control, alt and shift keys are strict.
+     *
+     * <li> When strict mode is enabled, setting any of these options to false means the key must not be pressed.</li>
+     * <li> When strict mode is disabled, setting any of these options to false means the key does not need to be pressed.</li>
+     *
+     * @return Whether the settings for meta, control, alt and shift keys are strict.
+     */
+    boolean strict() default false;
+
     /**
      * The target at which the event should be handled.
-     * <p>
-     * STAGE: The event will be handled by the stage
-     * <p>
-     * SCENE: The event will be handled by the scene
+     *
+     * <li> STAGE: The event will be handled by the stage</li>
+     * <li> SCENE: The event will be handled by the scene</li>
      *
      * @return The target at which the event should be handled
      */

--- a/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
+++ b/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
@@ -460,10 +460,12 @@ public class ReflectionSidecar<T> implements FxSidecar<T> {
         return (annotation.code() == KeyCode.UNDEFINED || event.getCode() == annotation.code()) &&
             (annotation.character().isEmpty() || event.getCharacter().equals(annotation.character())) &&
             (annotation.text().isEmpty() || event.getText().equals(annotation.text())) &&
-            (event.isShiftDown() || !annotation.shift()) &&
-            (event.isControlDown() || !annotation.control()) &&
-            (event.isAltDown() || !annotation.alt()) &&
-            (event.isMetaDown() || !annotation.meta());
+
+            // key pressed ==> not strict || key required
+            (event.isShiftDown() && (!annotation.strict() || annotation.shift())) &&
+            (event.isControlDown() && (!annotation.strict() || !annotation.control())) &&
+            (event.isAltDown() && (!annotation.strict() || !annotation.alt())) &&
+            (event.isMetaDown() && (!annotation.strict() || !annotation.meta()));
     }
 
     @Override

--- a/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
+++ b/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
@@ -457,15 +457,27 @@ public class ReflectionSidecar<T> implements FxSidecar<T> {
     }
 
     private boolean keyEventMatchesAnnotation(KeyEvent event, OnKey onKey) {
-        return
-            (onKey.code() == KeyCode.UNDEFINED || event.getCode() == onKey.code()) &&
-            (onKey.character().isEmpty() || event.getCharacter().equals(onKey.character())) &&
-            (onKey.text().isEmpty() || event.getText().equals(onKey.text())) &&
-
-            (((onKey.shift() && event.isShiftDown())) || (!onKey.shift() && !event.isShiftDown())) &&
-            (((onKey.control() && event.isControlDown())) || (!onKey.control() && !event.isControlDown())) &&
-            (((onKey.alt() && event.isAltDown())) || (!onKey.alt() && !event.isAltDown())) &&
-            (((onKey.meta() && event.isMetaDown())) || (!onKey.meta() && !event.isMetaDown()));
+        if (onKey.code() != KeyCode.UNDEFINED && event.getCode() != onKey.code()) {
+            return false;
+        }
+        if (!onKey.character().isEmpty() && !event.getCharacter().equals(onKey.character())) {
+            return false;
+        }
+        if (!onKey.text().isEmpty() && !event.getText().equals(onKey.text())) {
+            return false;
+        }
+        if (onKey.strict()) {
+            return onKey.shift() == event.isShiftDown()
+                && onKey.control() == event.isControlDown()
+                && onKey.alt() == event.isAltDown()
+                && onKey.meta() == event.isMetaDown();
+        } else {
+            // "!x || y" means "x <implies> y"
+            return (!onKey.shift() || event.isShiftDown())
+                && (!onKey.control() || event.isControlDown())
+                && (!onKey.alt() || event.isAltDown())
+                && (!onKey.meta() || event.isMetaDown());
+        }
     }
 
     @Override

--- a/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
+++ b/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
@@ -463,9 +463,9 @@ public class ReflectionSidecar<T> implements FxSidecar<T> {
 
             // key pressed ==> not strict || key required
             (event.isShiftDown() && (!annotation.strict() || annotation.shift())) &&
-            (event.isControlDown() && (!annotation.strict() || !annotation.control())) &&
-            (event.isAltDown() && (!annotation.strict() || !annotation.alt())) &&
-            (event.isMetaDown() && (!annotation.strict() || !annotation.meta()));
+            (event.isControlDown() && (!annotation.strict() || annotation.control())) &&
+            (event.isAltDown() && (!annotation.strict() || annotation.alt())) &&
+            (event.isMetaDown() && (!annotation.strict() || annotation.meta()));
     }
 
     @Override

--- a/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
+++ b/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
@@ -457,16 +457,15 @@ public class ReflectionSidecar<T> implements FxSidecar<T> {
     }
 
     private boolean keyEventMatchesAnnotation(KeyEvent event, OnKey onKey) {
-        return (onKey.code() == KeyCode.UNDEFINED || event.getCode() == onKey.code()) &&
+        return
+            (onKey.code() == KeyCode.UNDEFINED || event.getCode() == onKey.code()) &&
             (onKey.character().isEmpty() || event.getCharacter().equals(onKey.character())) &&
             (onKey.text().isEmpty() || event.getText().equals(onKey.text())) &&
 
-            // key required and key pressed || key not required and (not strict or strict and not pressed)
-            // If strict is enabled, the key must not be pressed
-            (onKey.shift() && event.isShiftDown()) || (!onKey.shift() && (!onKey.strict() || !event.isShiftDown())) &&
-            (onKey.control() && event.isControlDown()) || (!onKey.control() && (!onKey.strict() || !event.isControlDown())) &&
-            (onKey.alt() && event.isAltDown()) || (!onKey.alt() && (!onKey.strict() || !event.isAltDown())) &&
-            (onKey.meta() && event.isMetaDown()) || (!onKey.meta() && (!onKey.strict() || !event.isMetaDown()));
+            (((onKey.shift() && event.isShiftDown())) || (!onKey.shift() && !event.isShiftDown())) &&
+            (((onKey.control() && event.isControlDown())) || (!onKey.control() && !event.isControlDown())) &&
+            (((onKey.alt() && event.isAltDown())) || (!onKey.alt() && !event.isAltDown())) &&
+            (((onKey.meta() && event.isMetaDown())) || (!onKey.meta() && !event.isMetaDown()));
     }
 
     @Override

--- a/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
+++ b/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
@@ -456,16 +456,17 @@ public class ReflectionSidecar<T> implements FxSidecar<T> {
         };
     }
 
-    private boolean keyEventMatchesAnnotation(KeyEvent event, OnKey annotation) {
-        return (annotation.code() == KeyCode.UNDEFINED || event.getCode() == annotation.code()) &&
-            (annotation.character().isEmpty() || event.getCharacter().equals(annotation.character())) &&
-            (annotation.text().isEmpty() || event.getText().equals(annotation.text())) &&
+    private boolean keyEventMatchesAnnotation(KeyEvent event, OnKey onKey) {
+        return (onKey.code() == KeyCode.UNDEFINED || event.getCode() == onKey.code()) &&
+            (onKey.character().isEmpty() || event.getCharacter().equals(onKey.character())) &&
+            (onKey.text().isEmpty() || event.getText().equals(onKey.text())) &&
 
-            // key pressed ==> not strict || key required
-            (event.isShiftDown() && (!annotation.strict() || annotation.shift())) &&
-            (event.isControlDown() && (!annotation.strict() || annotation.control())) &&
-            (event.isAltDown() && (!annotation.strict() || annotation.alt())) &&
-            (event.isMetaDown() && (!annotation.strict() || annotation.meta()));
+            // key required and key pressed || key not required and (not strict or strict and not pressed)
+            // If strict is enabled, the key must not be pressed
+            (onKey.shift() && event.isShiftDown()) || (!onKey.shift() && (!onKey.strict() || !event.isShiftDown())) &&
+            (onKey.control() && event.isControlDown()) || (!onKey.control() && (!onKey.strict() || !event.isControlDown())) &&
+            (onKey.alt() && event.isAltDown()) || (!onKey.alt() && (!onKey.strict() || !event.isAltDown())) &&
+            (onKey.meta() && event.isMetaDown()) || (!onKey.meta() && (!onKey.strict() || !event.isMetaDown()));
     }
 
     @Override

--- a/ludo/src/main/java/de/uniks/ludo/controller/SetupController.java
+++ b/ludo/src/main/java/de/uniks/ludo/controller/SetupController.java
@@ -1,12 +1,17 @@
 package de.uniks.ludo.controller;
 
+import de.uniks.ludo.controller.sub.CreditModalComponent;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Slider;
+import javafx.scene.input.KeyCode;
 import org.fulib.fx.annotation.controller.Controller;
 import org.fulib.fx.annotation.controller.Title;
+import org.fulib.fx.annotation.event.OnKey;
+import org.fulib.fx.constructs.Modals;
 
 import javax.inject.Inject;
+import javax.inject.Provider;
 import java.util.Map;
 
 @Title("%setup.title")
@@ -19,6 +24,11 @@ public class SetupController extends BaseController {
     private Slider playerAmountSlider;
 
     @Inject
+    Provider<CreditModalComponent> versionProvider;
+    @Inject
+    Modals modals;
+
+    @Inject
     public SetupController() {
     }
 
@@ -26,6 +36,16 @@ public class SetupController extends BaseController {
     public void onPlayClick() {
         int playerAmount = (int) this.playerAmountSlider.getValue();
         this.app.show("ingame", Map.of("playerAmount", playerAmount));
+    }
+
+    @OnKey(code = KeyCode.I, control = true)
+    public void moveableInformation() {
+        modals.modal(versionProvider.get()).dialog(false).show();
+    }
+
+    @OnKey(code = KeyCode.I, control = false, strict = true)
+    public void information() {
+        modals.modal(versionProvider.get()).dialog(true).show();
     }
 
 }

--- a/ludo/src/main/java/de/uniks/ludo/controller/sub/CreditModalComponent.java
+++ b/ludo/src/main/java/de/uniks/ludo/controller/sub/CreditModalComponent.java
@@ -31,7 +31,7 @@ public class CreditModalComponent extends VBox {
         this.setBorder(Border.stroke(Paint.valueOf("black")));
         Label title = new Label("Ludo");
         title.setUnderline(true);
-        Label label = new Label("Powered by FulibFx.\nThis game has been created by LeStegii and ClashSoft.");
+        Label label = new Label("Powered by FulibFx.\nThis game has been created by LeStegii and Clashsoft.");
         Button ok = new Button("OK");
         ok.setOnAction(e -> modalStage.close());
 

--- a/ludo/src/main/java/de/uniks/ludo/controller/sub/CreditModalComponent.java
+++ b/ludo/src/main/java/de/uniks/ludo/controller/sub/CreditModalComponent.java
@@ -1,0 +1,42 @@
+package de.uniks.ludo.controller.sub;
+
+import de.uniks.ludo.App;
+import javafx.scene.control.Button;
+import javafx.scene.control.Label;
+import javafx.scene.layout.Border;
+import javafx.scene.layout.VBox;
+import javafx.scene.paint.Paint;
+import javafx.stage.Stage;
+import org.fulib.fx.annotation.controller.Component;
+import org.fulib.fx.annotation.event.OnRender;
+import org.fulib.fx.annotation.param.Param;
+
+import javax.inject.Inject;
+
+@Component
+public class CreditModalComponent extends VBox {
+
+    @Inject
+    App app;
+
+    @Param("modalStage")
+    Stage modalStage;
+
+    @Inject
+    public CreditModalComponent() {
+    }
+
+    @OnRender
+    public void render() {
+        this.setBorder(Border.stroke(Paint.valueOf("black")));
+        Label title = new Label("Ludo");
+        title.setUnderline(true);
+        Label label = new Label("Powered by FulibFx.\nThis game has been created by LeStegii and ClashSoft.");
+        Button ok = new Button("OK");
+        ok.setOnAction(e -> modalStage.close());
+
+        this.getChildren().addAll(title, label, ok);
+    }
+
+
+}


### PR DESCRIPTION
## General
- Added a `strict` option: If `strict` is enabled, setting an option like `shift` to `false` now requires the key **not** to be pressed instead of simply being ignored.

## Additional information
I'm not sure if this is the best solution. While it keeps backwards compatibility and doesn't break any behavior, it has the downside of not covering all situations that would be possible with e.g. an enum.

With this implementation, either all or no settings are strict. This means it is not possible to require `shift` not to be pressed whilst not caring if `alt` is pressed or not.

Addressing #101 
