### PR TITLE
Add new for loop constructor based on app

### DIFF
--- a/framework/src/main/java/org/fulib/fx/constructs/forloop/FxFor.java
+++ b/framework/src/main/java/org/fulib/fx/constructs/forloop/FxFor.java
@@ -2,12 +2,12 @@ package org.fulib.fx.constructs.forloop;
 
 import javafx.collections.ObservableList;
 import javafx.scene.Parent;
+import org.fulib.fx.FulibFxApp;
 import org.fulib.fx.annotation.controller.Component;
 import org.fulib.fx.controller.ControllerManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
-import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.util.Map;
@@ -21,9 +21,13 @@ public class FxFor {
 
     private final ControllerManager controllerManager;
 
-    @Inject
+    @Deprecated
     public FxFor(ControllerManager controllerManager) {
         this.controllerManager = controllerManager;
+    }
+
+    public FxFor(FulibFxApp app) {
+        this.controllerManager = app.frameworkComponent().controllerManager();
     }
 
     /**

--- a/framework/src/main/java/org/fulib/fx/constructs/forloop/FxFor.java
+++ b/framework/src/main/java/org/fulib/fx/constructs/forloop/FxFor.java
@@ -8,6 +8,7 @@ import org.fulib.fx.controller.ControllerManager;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import javax.inject.Inject;
 import javax.inject.Provider;
 import javax.inject.Singleton;
 import java.util.Map;
@@ -26,6 +27,7 @@ public class FxFor {
         this.controllerManager = controllerManager;
     }
 
+    @Inject
     public FxFor(FulibFxApp app) {
         this.controllerManager = app.frameworkComponent().controllerManager();
     }


### PR DESCRIPTION
## Improvements/Deprecations
This PR adds a new constructor to the `FxFor` class, allowing to create an instance using a `FulibFx` instance instead of passing a `ControllerManager` directly.

- Added new constructor taking `FulibFxApp` as an argument
- Deprecated old constructor taking `ControllerManager` as an argument

