### PR TITLE
Generate reflective clearChildren if component does not extend Pane

### DIFF
--- a/annotation-processor/src/main/java/org/fulib/fx/FxClassGenerator.java
+++ b/annotation-processor/src/main/java/org/fulib/fx/FxClassGenerator.java
@@ -44,6 +44,10 @@ public class FxClassGenerator {
      * The `javafx.scene.Parent` type.
      */
     private final TypeMirror parent;
+    /**
+     * The `javafx.scene.layout.Pane` type.
+     */
+    private final TypeMirror pane;
 
     public FxClassGenerator(ProcessingHelper helper, ProcessingEnvironment processingEnv) {
         this.helper = helper;
@@ -61,6 +65,7 @@ public class FxClassGenerator {
             .orElseThrow();
 
         parent = processingEnv.getElementUtils().getTypeElement("javafx.scene.Parent").asType();
+        pane = processingEnv.getElementUtils().getTypeElement("javafx.scene.layout.Pane").asType();
     }
 
     public void generateSidecar(TypeElement componentClass) {
@@ -303,9 +308,7 @@ public class FxClassGenerator {
             if (view.isEmpty()) {
                 out.println("    final Node result = instance;");
             } else {
-                if (processingEnv.getTypeUtils().isAssignable(componentClass.asType(), parent)) {
-                    out.println("    instance.getChildren().clear();");
-                }
+                generateClearChildren(out, componentClass);
                 out.printf("    final Node result = this.controllerManager.loadFXML(%s, instance, true);%n", helper.stringLiteral(view));
             }
         } else if (controller != null) {
@@ -316,6 +319,14 @@ public class FxClassGenerator {
                 final String inferredView = view.isEmpty() ? ControllerUtil.transform(componentClass.getSimpleName().toString()) + ".fxml" : view;
                 out.printf("    final Node result = this.controllerManager.loadFXML(%s, instance, false);%n", helper.stringLiteral(inferredView));
             }
+        }
+    }
+
+    private void generateClearChildren(PrintWriter out, TypeElement componentClass) {
+        if (processingEnv.getTypeUtils().isAssignable(componentClass.asType(), pane)) {
+            out.println("    instance.getChildren().clear();");
+        } else if (processingEnv.getTypeUtils().isAssignable(componentClass.asType(), parent)) {
+            out.println("    org.fulib.fx.util.ReflectionUtil.getChildrenList(instance.getClass(), instance).clear();");
         }
     }
 

--- a/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
+++ b/framework/src/main/java/org/fulib/fx/controller/internal/ReflectionSidecar.java
@@ -7,6 +7,7 @@ import javafx.scene.Node;
 import javafx.scene.Parent;
 import javafx.scene.input.KeyCode;
 import javafx.scene.input.KeyEvent;
+import javafx.scene.layout.Pane;
 import org.fulib.fx.FulibFxApp;
 import org.fulib.fx.annotation.controller.*;
 import org.fulib.fx.annotation.event.OnDestroy;
@@ -370,10 +371,7 @@ public class ReflectionSidecar<T> implements FxSidecar<T> {
                 node = (Node) instance;
             } else {
                 Node root = (Node) instance;
-                // Due to the way JavaFX works, we have to clear the children list of the old root before loading its fxml file again
-                if (root instanceof Parent parent) {
-                    ReflectionUtil.getChildrenList(instance.getClass(), parent).clear();
-                }
+                clearChildren(root);
                 node = controllerManager.loadFXML(view, instance, true);
             }
         }
@@ -404,6 +402,15 @@ public class ReflectionSidecar<T> implements FxSidecar<T> {
             node = controllerManager.loadFXML(fxmlPath, instance, false);
         }
         return node;
+    }
+
+    private void clearChildren(Node node) {
+        // Due to the way JavaFX works, we have to clear the children list of the old root before loading its fxml file again
+        if (node instanceof Pane pane) {
+            pane.getChildren().clear();
+        } else if (node instanceof Parent parent) {
+            ReflectionUtil.getChildrenList(node.getClass(), parent).clear();
+        }
     }
 
     /**

--- a/framework/src/test/java/org/fulib/fx/app/controller/types/ListViewComponent.java
+++ b/framework/src/test/java/org/fulib/fx/app/controller/types/ListViewComponent.java
@@ -1,0 +1,9 @@
+package org.fulib.fx.app.controller.types;
+
+import javafx.scene.control.ListView;
+import org.fulib.fx.annotation.controller.Component;
+
+// https://github.com/fujaba/fulibFx/issues/113
+@Component(view = "ListView.fxml")
+public class ListViewComponent<T> extends ListView<T> {
+}

--- a/framework/src/test/resources/org/fulib/fx/app/controller/types/ListView.fxml
+++ b/framework/src/test/resources/org/fulib/fx/app/controller/types/ListView.fxml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+
+<?import javafx.scene.control.ListView?>
+<fx:root type="ListView" prefHeight="200.0" prefWidth="200.0" xmlns="http://javafx.com/javafx/22"
+         xmlns:fx="http://javafx.com/fxml/1"/>


### PR DESCRIPTION
## Bugfixes

* Fixed a compilation error in generated sidecar classes for FXML view components that don't extend `Pane` in some way.

Closes #113