### PR TITLE
Enhance modal initializer docs

### DIFF
--- a/docs/features/4-modals.md
+++ b/docs/features/4-modals.md
@@ -6,23 +6,27 @@ can be used to display popup windows, dialogs, etc.
 The framework provides a `Modals` class that can be used to display a modal.
 Using a builder, a stage can be configured and then be displayed.
 
-A BiConsumer provides access to the component instance and the stage for configuring things the builder doesn't provide.
+An Initializer in the form of a BiConsumer provides access to the component instance and the stage for configuring
+things the builder doesn't provide.
 It can be set using `init()`.
+Initializers are called after the component has been created, initialized and rendered, but before the stage is shown.
 
 Enabling `dialog()` adds some default styling to the stage.
 This has been added as an option to enable the legacy default styling present in the old modal class.
 
 Parameters can be passed by using the `param()` method in form of a map (see `show()` in the `FulibFxApp` class).
 
-Enabling `destroyOnClose()` configures the component to be destroyed upon closing the modal. 
+Enabling `destroyOnClose()` configures the component to be destroyed upon closing the modal.
 This is enabled by default and shouldn't be changed if not necessary.
 
-The stage can either be built using `build()` and then displayed by yourself, or built and displayed at once using `show()`.
+The stage can either be built using `build()` and then displayed by yourself, or built and displayed at once
+using `show()`.
 
 When displaying the component, the parameters `modalStage` and `ownerStage` will be passed so that the modal can for
 example be closed from inside the component class.
 
-The same component instance cannot be used twice for displaying a modal. When using Dagger it is recommended to inject a provider and use it to create an instance for every modal.
+The same component instance cannot be used twice for displaying a modal. When using Dagger it is recommended to inject a
+provider and use it to create an instance for every modal.
 
 ```java
 

--- a/docs/features/4-modals.md
+++ b/docs/features/4-modals.md
@@ -1,13 +1,12 @@
 # Modals [![Javadocs](https://javadoc.io/badge2/org.fulib/fulibFx/Javadocs.svg?color=green)](https://javadoc.io/doc/org.fulib/fulibFx/latest/org/fulib/fx/controller/Modals.html)
 
-Modals are a special type of window that can be used to display a controller on top of another controller. Modals
-can be used to display popup windows, dialogs, etc.
+Modals are a special type of window that can be used to display a controller on top of another controller. 
+Modals can be used to display popup windows, dialogs, etc.
 
 The framework provides a `Modals` class that can be used to display a modal.
 Using a builder, a stage can be configured and then be displayed.
 
-An Initializer in the form of a BiConsumer provides access to the component instance and the stage for configuring
-things the builder doesn't provide.
+An Initializer in the form of a BiConsumer provides access to the component instance and the stage for configuring things the builder doesn't provide.
 It can be set using `init()`.
 Initializers are called after the component has been created, initialized and rendered, but before the stage is shown.
 
@@ -19,14 +18,11 @@ Parameters can be passed by using the `param()` method in form of a map (see `sh
 Enabling `destroyOnClose()` configures the component to be destroyed upon closing the modal.
 This is enabled by default and shouldn't be changed if not necessary.
 
-The stage can either be built using `build()` and then displayed by yourself, or built and displayed at once
-using `show()`.
+The stage can either be built using `build()` and then displayed by yourself, or built and displayed at once using `show()`.
 
-When displaying the component, the parameters `modalStage` and `ownerStage` will be passed so that the modal can for
-example be closed from inside the component class.
+When displaying the component, the parameters `modalStage` and `ownerStage` will be passed so that the modal can for example be closed from inside the component class.
 
-The same component instance cannot be used twice for displaying a modal. When using Dagger it is recommended to inject a
-provider and use it to create an instance for every modal.
+The same component instance cannot be used twice for displaying a modal. When using Dagger it is recommended to inject a provider and use it to create an instance for every modal.
 
 ```java
 

--- a/framework/src/main/java/org/fulib/fx/constructs/Modals.java
+++ b/framework/src/main/java/org/fulib/fx/constructs/Modals.java
@@ -78,7 +78,10 @@ public class Modals {
         }
 
         /**
-         * Adds an initializer.
+         * Adds an initializer for the modal stage.
+         * Initializers are called after the component has been initialized and rendered and the stage has been created,
+         * but before the stage is shown.
+         * They can be used to set additional properties on the stage or the component.
          * <p>
          * If another initializer has been added already, the new initializer will be called after the previous one.
          *
@@ -114,6 +117,8 @@ public class Modals {
          * <p>
          * This will set the stage style to {@link StageStyle#TRANSPARENT}, the modality to {@link Modality#WINDOW_MODAL}
          * and the scene fill to transparent (see {@link ModalBuilder#FULIBFX_DIALOG}).
+         * <p>
+         * This initializer will be called before any other initializer.
          *
          * @param dialog Whether the default dialog options should be used
          * @return The current modal instance


### PR DESCRIPTION
This PR enhances the modal documentation for initializers, but is also meant for discussing the future of the legacy modal class.

## General

- Enhanced javadocs for initializer related methods
- Enhanced documentation for modals

We should also discuss what happens with the legacy modal class. It has been deprecated for more than two months now, so removing it might be a good idea.

Closes #115 
