### PR TITLE
feat(framework): Support ReusableItemComponent in FxFor

### DIFF
--- a/docs/features/2-for.md
+++ b/docs/features/2-for.md
@@ -11,11 +11,14 @@ fxFor.of(container, items, myComponentProvider);
 ```
 
 This will create a component for each item in the list `items` and add it to the children of the `container` (e.g. a VBox).
+If the component implements the `ReusableItemComponent` interface, `setItem` will be called instead of creating a new instance.
+For more information see [this section](7-componentlistcell.md#reusableitemcomponent-).
 
 Currently, no information is passed to the created component. In order to pass static information you can add
 parameters like you would when using the `show`-method using a map.
 
-When a new component is created, the parameters `item` and `list` are automatically added to the map. The `item` parameter contains the current item of the component and the `list` parameter contains the list of all items.
+When a new component is created, the parameters `item` and `list` are automatically added to the map. 
+The `item` parameter contains the current item of the component and the `list` parameter contains the list of all items.
 If parameters with the same key are already present in the map, they will not be overwritten.
 
 ```java

--- a/docs/features/7-componentlistcell.md
+++ b/docs/features/7-componentlistcell.md
@@ -1,7 +1,9 @@
 # Component List Cells [![Javadocs](https://javadoc.io/badge2/org.fulib/fulibFx/Javadocs.svg?color=green)](https://javadoc.io/doc/org.fulib/fulibFx/latest/org/fulib/fx/constructs/listview/ComponentListCell.html)
 
-Component List Cells can be used to display a subcomponent as a cell in a ListView. Whenever an item is added to or removed from the list, the subcomponent updates accordingly.
-The `ComponentListCell` class is a subclass of the `ListCell` class and can be used in the same way. The `ComponentListCell` can be used to set the cell factory of a `ListView` to display a subcomponent for each item in the list.
+Component List Cells can be used to display a subcomponent as a cell in a ListView. 
+Whenever an item is added to or removed from the list, the subcomponent updates accordingly.
+The `ComponentListCell` class is a subclass of the `ListCell` class and can be used in the same way. 
+The `ComponentListCell` can be used to set the cell factory of a `ListView` to display a subcomponent for each item in the list.
 
 ```java
 @Controller
@@ -28,7 +30,7 @@ public class MainController {
 }
 ```
 
-### ReusableItemComponent [![Javadocs](https://javadoc.io/badge2/org.fulib/fulibFx/Javadocs.svg?color=green)](https://javadoc.io/doc/org.fulib/fulibFx/latest/org/fulib/fx/constructs/listview/ReusableItemComponent.html)
+### ReusableItemComponent [![Javadocs](https://javadoc.io/badge2/org.fulib/fulibFx/Javadocs.svg?color=green)](https://javadoc.io/doc/org.fulib/fulibFx/latest/org/fulib/fx/constructs/ReusableItemComponent.html)
 If the component implements the `ReusableItemComponent` interface, the `ComponentListCell` will call the `setItem` method of the component whenever the item changes. This allows the component to update its view based on the new item.
 If the component doesn't implement this interface, it will be destroyed and a new component will be created whenever the item changes.
 

--- a/framework/src/main/java/org/fulib/fx/constructs/ReusableItemComponent.java
+++ b/framework/src/main/java/org/fulib/fx/constructs/ReusableItemComponent.java
@@ -1,9 +1,9 @@
-package org.fulib.fx.constructs.listview;
+package org.fulib.fx.constructs;
 
 import org.jetbrains.annotations.NotNull;
 
 /**
- * Interface for components that can be reused in a list view.
+ * Interface for components that can be reused inside other constructs.
  * If a component implements this interface, it can be reused when its item changes instead of being destroyed and recreated.
  * <p>
  * The component is fully responsible for updating its display when the item changes.

--- a/framework/src/main/java/org/fulib/fx/constructs/listview/ComponentListCell.java
+++ b/framework/src/main/java/org/fulib/fx/constructs/listview/ComponentListCell.java
@@ -4,6 +4,7 @@ import javafx.scene.Parent;
 import javafx.scene.control.ContentDisplay;
 import javafx.scene.control.ListCell;
 import org.fulib.fx.FulibFxApp;
+import org.fulib.fx.constructs.ReusableItemComponent;
 
 import javax.inject.Provider;
 import java.util.HashMap;

--- a/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
+++ b/framework/src/test/java/org/fulib/fx/app/FrameworkTest.java
@@ -140,7 +140,11 @@ public class FrameworkTest extends ApplicationTest {
         FX_SCHEDULER.scheduleDirect(() -> list.add(1, "World"));
         waitForFxEvents();
 
+        FX_SCHEDULER.scheduleDirect(() -> list.set(1, "Everyone"));
+        waitForFxEvents();
+
         assertEquals(3, container.getChildren().size());
+
     }
 
     @Test

--- a/framework/src/test/java/org/fulib/fx/app/controller/subcomponent/basic/ButtonSubComponent.java
+++ b/framework/src/test/java/org/fulib/fx/app/controller/subcomponent/basic/ButtonSubComponent.java
@@ -2,15 +2,21 @@ package org.fulib.fx.app.controller.subcomponent.basic;
 
 import org.fulib.fx.annotation.controller.Component;
 import javafx.scene.control.Button;
+import org.fulib.fx.constructs.ReusableItemComponent;
+import org.jetbrains.annotations.NotNull;
 
 import javax.inject.Inject;
 
 @Component
-public class ButtonSubComponent extends Button {
+public class ButtonSubComponent extends Button implements ReusableItemComponent<String> {
 
     @Inject
     public ButtonSubComponent() {
         this.setText("Sub Component Button");
     }
 
+    @Override
+    public void setItem(@NotNull String item) {
+        this.setText(item);
+    }
 }


### PR DESCRIPTION
FxFor now supports `ReusableItemComponent`s. When the node used implements the interface, replacing an item will cause the node to update instead of being removed and readded.

`setItem` will be called once after init/render and then each time the item is replaced without re-rendering.

Closes #118 
