### PR TITLE
Fix exception upon refresh

### DIFF
--- a/framework/src/main/java/org/fulib/fx/controller/Router.java
+++ b/framework/src/main/java/org/fulib/fx/controller/Router.java
@@ -255,7 +255,7 @@ public class Router {
         Either<TraversableNodeTree.Node<Provider<?>>, Object> either = this.history.current().getKey();
         return new Pair<>(
                 either.isLeft() ?
-                        either.getLeft().map(node -> ((Provider<?>) Objects.requireNonNull(node.value()).get())).orElseThrow() :
+                        either.getLeft().map(node -> ((Provider<?>) Objects.requireNonNull(node.value()))).orElseThrow() :
                         either.getRight().orElseThrow(),
                 this.history.current().getValue()
         );


### PR DESCRIPTION
Refreshing previously caused an exception due to `get()` being incorrectly called on a provider instead of returning the provider itself.