### PR TITLE
New error message format

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,7 @@ A list of all possible error codes can be found [here](ERROR_CODES.md).
 ### 1. The framework throws an exception when doing something
 All exceptions thrown by the framework are listed in the [error code documentation](ERROR_CODES.md). 
 When the framework throws an exception, it will print the error code and a short description of the error to the console.
-If for example the error `java.lang.IllegalArgumentException: Class '*' is not a component. [FFX1000]` is thrown, you can 
-check the error code documentation for [FFX1000](ERROR_CODES.md#1000-class--is-not-a-component) to find out what the error 
-means and how to fix it.
+If for example the error `java.lang.IllegalArgumentException: FFX1000: Class '*' is not a component.` is thrown, you can check the error code documentation for [FFX1000](ERROR_CODES.md#1000-class--is-not-a-component) to find out what the error means and how to fix it.
 
 ### 2. My route is not found even though it is registered
 When using `show("route/to/controller")` without a leading "`/`", the route is relative to the currently displayed controller. 

--- a/framework/src/main/java/org/fulib/fx/util/FrameworkUtil.java
+++ b/framework/src/main/java/org/fulib/fx/util/FrameworkUtil.java
@@ -12,7 +12,7 @@ public class FrameworkUtil {
     }
 
     public static String error(int id) {
-        return ERROR_BUNDLE.getString(String.valueOf(id)) + " [FFX" + id + "]";
+        return "FFX" + id + ": " + ERROR_BUNDLE.getString(String.valueOf(id));
     }
 
     public static String note(int id) {

--- a/ludo/src/main/java/de/uniks/ludo/App.java
+++ b/ludo/src/main/java/de/uniks/ludo/App.java
@@ -39,6 +39,9 @@ public class App extends FulibFxApp {
             // Setting the default resource bundle of the application to the resource bundle provided by the component
             setDefaultResourceBundle(component.bundle());
 
+            primaryStage.setWidth(1200);
+            primaryStage.setHeight(800);
+
             // Adding a key event handler to the stage, which listens for the F5 key to refresh the application
             stage().addEventHandler(KEY_RELEASED, event -> {
                 if (event.getCode() == KeyCode.F5) {

--- a/ludo/src/test/java/de/uniks/ludo/AppTest.java
+++ b/ludo/src/test/java/de/uniks/ludo/AppTest.java
@@ -27,9 +27,6 @@ public class AppTest extends ApplicationTest {
 
     @Test
     public void test() {
-        Platform.runLater(() -> app.stage().requestFocus());
-        waitForFxEvents();
-
         press(KeyCode.LEFT);
         release(KeyCode.LEFT);
         press(KeyCode.TAB);


### PR DESCRIPTION
- Changed error format from `description [FFX0000]` to `FFX0000: description`.
  This is compatible with tools like TypeScript which produce the same format.
- Fixed ludo test stage.